### PR TITLE
adjust question image dimensions

### DIFF
--- a/fragenautomat/static/css/fragenautomat.css
+++ b/fragenautomat/static/css/fragenautomat.css
@@ -109,9 +109,6 @@ img#legal {
 }
 
 .question-image {
-  height: 12rem;
-  display: block;
-  object-fit: contain;
   border-style: solid;
   border-width: 1px;
   border-radius: 0.25rem;


### PR DESCRIPTION
This PR removes the defined height for question images to make them expand to full width inside the container.

**_Before:_** 
![image](https://user-images.githubusercontent.com/23213965/108634986-e6b01c00-747c-11eb-915a-4e51fe6d7dc7.png)

**_After:_**
![image](https://user-images.githubusercontent.com/23213965/108634996-fe87a000-747c-11eb-930a-f2f880c9b2fb.png)
